### PR TITLE
fix: Arrumado bug que ao entrar num diálogo e, ao mesmo tempo, mudasse de sala, travava o jogo

### DIFF
--- a/objects/objWarp/Step_0.gml
+++ b/objects/objWarp/Step_0.gml
@@ -1,3 +1,7 @@
+if (variable_global_exists("dialog") && global.dialog) {
+	exit
+}
+
 if place_meeting(x, y, objPlayer) and !instance_exists(objFade) {
 		var instantiated = instance_create_depth(0, 0, -9999, objFade);
 		instantiated.target_x = target_x;


### PR DESCRIPTION
objWarp verifica se a variável _global_diago_ está como _true_ e se ela existe. Caso sim, não teleporta o jogador. Caso contrário, teleporta-o.
Closes #47 