### PR TITLE
fix: Travamento no minigame do armário

### DIFF
--- a/objects/objSchoolLocker/Step_0.gml
+++ b/objects/objSchoolLocker/Step_0.gml
@@ -1,4 +1,4 @@
-if (srcCanOpenDialog()) {
+if (!modoInspecao && srcCanOpenDialog()) {
     dialogInitialized = true;
 }
 if (mouse_check_button_pressed(mb_left) && !position_meeting(mouse_x, mouse_y, id)) {
@@ -48,8 +48,8 @@ if (dialogInitialized && distance_to_object(objPlayer) <= 15) {
         dialogInitialized = false;
     }
 }
-// Sair do modo com ESC
-if (modoInspecao && keyboard_check_pressed(vk_escape)) {
+// Sair do modo com a tecla de ESPAÇO
+if (modoInspecao && keyboard_check_pressed(vk_space)) {
     // Restaurar armário
     x = posicaoOriginalX;
     y = posicaoOriginalY;
@@ -74,4 +74,5 @@ if (modoInspecao && keyboard_check_pressed(vk_escape)) {
         instance_destroy(objGame);
     }
     global.dialog = false;
+	dialogInitialized = false;
 }


### PR DESCRIPTION
- O primeiro erro "armário sem senha" ocorria por que a tecla usada tanto para sair da janela do armário, quanto para pausar o jogo era "esc". Minha solução foi mudar a tecla para "space". Agora, o jogador pode sair da janela do armário e buscar pelo papel com senha.
- O segundo erro não me ocorreu. Porém, eu encontrei um bug um tanto escondido. Ao clicar fora da box de interação de objSchoolLocker e fechar a janela desse objeto, o jogo abria a janela inicializando, novamente, os diálogos. A correção foi adicionar a variável _modoInspecao_ dentro de `if (srcCanOpenDialog) {}` para evitar que isso acontecesse. Além disso, a linha _dialogInitialized = false;_ para assegurar que o diálogo terminou ao fechar a janela. 
Closes #79 